### PR TITLE
avoid defining all the ancestors methods

### DIFF
--- a/lib/pry-singular.rb
+++ b/lib/pry-singular.rb
@@ -11,7 +11,7 @@ module PrySingular
 
     def import_class_command(klass)
       commands = Pry::CommandSet.new do
-        klass.public_methods.each do |klass_method|
+        klass.singleton_methods.each do |klass_method|
           command "#{klass_method}", "#{klass}.#{klass_method}" do
             klass.class_eval <<-EOS
               #{Readline::HISTORY.to_a.last.gsub(' ', '')}

--- a/test/pry-singular_test.rb
+++ b/test/pry-singular_test.rb
@@ -21,4 +21,9 @@ class PrySingularTest < Minitest::Test
     assert_includes(Pry::Commands.list_commands, "hello")
     assert_includes(Pry::Commands.list_commands, "oha")
   end
+
+  def test_avoid_setting_ancestors_class_methods
+    refute_includes(Pry::Commands.list_commands, "class")
+    refute_includes(Pry::Commands.list_commands, "new")
+  end
 end


### PR DESCRIPTION
as per the discussion at: https://github.com/QWYNG/pry-singular/issues/1

Basically it only includes class methods from the specified class itself(*)

*note: it also includes methods from included/prepended modules on the class. you could import strictly only the singleton method on the class, but it might omit important methods that you would expect to incorporate (see below)

```ruby
> FactoryBot.singleton_methods(true) - FactoryBot.singleton_methods(false)
=> [:define,
 :modify,
 :create,
 :null,
 :attributes_for,
 :build_list,
 :build,
 :build_stubbed,
 :build_pair,
 :create_list,
 :create_pair,
 :attributes_for_list,
 :generate_list,
 :attributes_for_pair,
 :generate,
 :build_stubbed_pair,
 :build_stubbed_list,
 :null_pair,
 :null_list]
```

For the reason above, I would suggest to import methods using singleton_methods (with its default argument = true).